### PR TITLE
Enable logspout syslog+TLS

### DIFF
--- a/roles/coreos/templates/master.cloud-config.j2
+++ b/roles/coreos/templates/master.cloud-config.j2
@@ -143,8 +143,8 @@ coreos:
         EnvironmentFile=/etc/environment
         ExecStartPre=-/usr/bin/docker kill logspout
         ExecStartPre=-/usr/bin/docker rm logspout
-        ExecStartPre=/usr/bin/docker pull gliderlabs/logspout:latest
-        ExecStart=/usr/bin/docker run --name logspout -v /var/run/docker.sock:/tmp/docker.sock gliderlabs/logspout syslog://logs3.papertrailapp.com:51722
+        ExecStartPre=/usr/bin/docker pull gliderlabs/logspout:master
+        ExecStart=/usr/bin/docker run --name logspout -v /var/run/docker.sock:/tmp/docker.sock gliderlabs/logspout:master syslog+tls://logs3.papertrailapp.com:51722
         ExecStop=/usr/bin/docker stop logspout
   
   update:

--- a/roles/coreos/templates/worker.cloud-config.j2
+++ b/roles/coreos/templates/worker.cloud-config.j2
@@ -124,8 +124,8 @@ coreos:
         EnvironmentFile=/etc/environment
         ExecStartPre=-/usr/bin/docker kill logspout
         ExecStartPre=-/usr/bin/docker rm logspout
-        ExecStartPre=/usr/bin/docker pull gliderlabs/logspout:latest
-        ExecStart=/usr/bin/docker run --name logspout -v /var/run/docker.sock:/tmp/docker.sock gliderlabs/logspout syslog://logs3.papertrailapp.com:51722
+        ExecStartPre=/usr/bin/docker pull gliderlabs/logspout:master
+        ExecStart=/usr/bin/docker run --name logspout -v /var/run/docker.sock:/tmp/docker.sock gliderlabs/logspout:master syslog+tls://logs3.papertrailapp.com:51722
         ExecStop=/usr/bin/docker stop logspout
 
   update:


### PR DESCRIPTION
@greg @snorecone TLS isn't supported in gliderlabs/logspout:latest as that now points to release, not master.  TLS support was added via https://github.com/gliderlabs/logspout/issues/116, so we need to point to gliderlabs/logspout:master instead.  Then it's just syslog+tls://uri.  

They do not (https://github.com/gliderlabs/logspout/blob/master/transports/tls/tls.go#L25) allow you to pass in a config object to configure the TLS client, so it will use default values (see https://golang.org/src/crypto/tls/common.go?s=8571:13264#L235)
