### PR TITLE
Add notificaption.yml

### DIFF
--- a/services/notificaption.yml
+++ b/services/notificaption.yml
@@ -36,7 +36,7 @@ tasks:
             containerPort: 9099
             protocol: tcp
         command:
-          - "/run.sh"
+          - "npm start"
 
 services:
   - serviceName: notificaption


### PR DESCRIPTION
Hey @snorecone and/or @grepory and/or @coreylight, could one of you kindly take a look at this when you get a sec? :) It's all new to me. 

I :snake:d most of it from `spanx.yml` and then:
- changed the ports to `9099` (not in use by anything else)
- switched `tasks > command` to start up the node server

The docker image lives at https://quay.io/repository/opsee/notificaption?tag=latest. 

So, once this is merged in to `compute` and I run `make` locally, can I do `./run deploy production notificaption latest`? 
